### PR TITLE
Move graphql to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   },
   "author": "",
   "license": "MIT",
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
   "dependencies": {
     "@divyenduz/graphql-language-service-interface": "^1.2.5",
     "@divyenduz/graphql-language-service-server": "1.2.3",
     "@divyenduz/graphql-language-service-types": "1.1.3",
-    "graphql": "^0.12.3",
     "graphql-config": "^2.1.0",
     "typescript-template-language-service-decorator": "^1.2.0"
   },


### PR DESCRIPTION
To avoid having multiple versions of `graphql` in the dependency tree, the already installed version can be reused.